### PR TITLE
Fixed edge-case bugs with 'min' and 'max' command line options.

### DIFF
--- a/src/Arbogen.ml
+++ b/src/Arbogen.ml
@@ -75,7 +75,8 @@ let () =
                     end
                   else begin
                       global_options.size_min <- n;
-                      global_options.size_min_set <- true
+                      global_options.size_min_set <- true;
+                      global_options.size_max <- (n + 10); (* Re-up default maximum *)
                     end),
        "<n> : set the minimum size for the generated tree to <n> (a strictly positive integer)");
       ("-max", Arg.Int
@@ -85,12 +86,12 @@ let () =
                       eprintf "Error: wrong maximum size %d => must be strictly positive\n...aborting\n%!" n ;
                       exit 1;
                     end
-                  else if n < global_options.size_min then
+                  else if n <= global_options.size_min then
                     begin
                       eprintf "Error: wrong maximum size %d => must be strictly bigger than minimum\n...aborting\n%!" n ;
                       exit 1;
                     end
-                  else  begin
+                  else begin
                       global_options.size_max <- n;
                       global_options.size_max_set <- true
                     end),


### PR DESCRIPTION
Previously, when only specifying the minimum (either at command line, or through configuration file), one may end up in a state where the default maximum (20) is smaller than the specified minimum. In this situation, the program fails to generate a sample without proper error reporting.

This small patch makes sure that when the minimum is changed, the maximum is appropriately adjusted as well.

Another small bug that is fixed is to have proper error reporting when the specified maximum is equal to the minimum.