### PR TITLE
allow C-style multi-line comments

### DIFF
--- a/src/Lexer.mll
+++ b/src/Lexer.mll
@@ -73,7 +73,12 @@ rule token = parse
   | times { TIMES }
   | lparen { LPAREN }
   | rparen { RPAREN }
+  | "/*"     { comment lexbuf }
   | eof { EOF }
   | _ { failwith ("Unknown symbol " ^ Lexing.lexeme lexbuf) }
-{
-}
+
+and comment = parse
+  | "*/"     { token lexbuf }
+  | newline  { Lexing.new_line lexbuf; comment lexbuf }
+  | eof      { failwith "unterminated comment" }
+  | _        { comment lexbuf }


### PR DESCRIPTION
This makes `examples/binary.spec` syntactically correct